### PR TITLE
Packaging for SASS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+ - `ALICA_for_SASS.jar` build which contains necessary classes for
+   using Analyzers and Controllers in SASS.
+
 ## [v0.2.5]
 
 ### Added

--- a/build.xml
+++ b/build.xml
@@ -45,7 +45,7 @@
         <echo message="Packaging analyzers and controllers into a single JAR at dist/ALICA_for_SASS.jar"/>
         <jar destfile="dist/ALICA_for_SASS.jar"
             basedir="build/classes"
-            includes="**/analyzers/**/*.class,**/controllers/**/*.class,**/alica/Analyzer.class,**/alica/Controller.class,**/alica/AbstractFactory.class"/>
+            includes="**/analyzers/**/*.class,**/controllers/**/*.class,**/alica/Analyzer.class,**/alica/Controller.class,**/alica/AlicaLogger.class,**/alica/AbstractFactory.class"/>
         <echo message="Finished" />
     </target>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -14,6 +14,8 @@
     <property name="store.jar.name" value="ALICA_dev.jar"/>
     <property name="store.dir" value="store"/>
     <property name="store.jar" value="${store.dir}/${store.jar.name}"/>
+    
+    
     <target name="-pre-jar">
         <!-- Single file -->
         <copy file="src/resources/leb_logo_small.png" todir="${build.dir}/classes/resources" />
@@ -37,7 +39,13 @@
         </zip>
         <delete file="${store.dir}/temp_final.jar"/>
         <copy file="${store.jar}" toDir="${basedir}/dist/" />
+        
         <delete dir="${store.dir}"/>
+        
+        <echo message="Packaging analyzers and controllers into a single JAR at dist/ALICA_for_SASS.jar"/>
+        <jar destfile="dist/ALICA_for_SASS.jar"
+            basedir="build/classes"
+            includes="**/analyzers/**/*.class,**/controllers/**/*.class,**/alica/Analyzer.class,**/alica/Controller.class,**/alica/AbstractFactory.class"/>
         <echo message="Finished" />
     </target>
 </project>

--- a/src/ch/epfl/leb/alica/AbstractFactory.java
+++ b/src/ch/epfl/leb/alica/AbstractFactory.java
@@ -59,8 +59,6 @@ public abstract class AbstractFactory<ProductSetupPanel> {
      * @return currently selected factory product
      */
     public String getSelectedProductName() {
-        if (selected_name == null)
-            throw new NullPointerException("No product selected.");
         return selected_name;
     }
     
@@ -85,6 +83,10 @@ public abstract class AbstractFactory<ProductSetupPanel> {
      * @param name identifier of the product
      */
     public void selectProduct(String name) {
+        if (name == null) {
+            selected_name = null;
+            return;
+        }
         if (!setup_panels.containsKey(name)) {
             throw new IllegalArgumentException("No such product: "+name);
         }
@@ -96,6 +98,8 @@ public abstract class AbstractFactory<ProductSetupPanel> {
      * @return Return setup panel of currently selected product
      */
     public ProductSetupPanel getSelectedSetupPanel() {
+        if (selected_name==null)
+            return null;
         return setup_panels.get(selected_name);
     }
 }

--- a/src/ch/epfl/leb/alica/MainGUI.form
+++ b/src/ch/epfl/leb/alica/MainGUI.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<Form version="1.3" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JFrameFormInfo">
+<Form version="1.3" maxVersion="1.8" type="org.netbeans.modules.form.forminfo.JFrameFormInfo">
   <NonVisualComponents>
     <Component class="javax.swing.ButtonGroup" name="buttonGroup_imaging_mode">
     </Component>
@@ -12,7 +12,6 @@
   </Properties>
   <SyntheticProperties>
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
-    <SyntheticProperty name="generateCenter" type="boolean" value="false"/>
   </SyntheticProperties>
   <Events>
     <EventHandler event="windowClosing" listener="java.awt.event.WindowListener" parameters="java.awt.event.WindowEvent" handler="formWindowClosing"/>

--- a/src/ch/epfl/leb/alica/MainGUI.java
+++ b/src/ch/epfl/leb/alica/MainGUI.java
@@ -107,19 +107,23 @@ public final class MainGUI extends JFrame {
     private void updateAnalyzerSetupPanel() {
         analyzer_panel.removeAll();
         javax.swing.JPanel panel = alica_core.getAnalyzerFactory().getSelectedSetupPanel();
-        analyzer_panel.add(panel);
-        panel.setBounds(5,5,200,150);
-        panel.revalidate();
-        panel.repaint();
+        if (panel != null) {
+            analyzer_panel.add(panel);
+            panel.setBounds(5,5,200,150);
+            panel.revalidate();
+            panel.repaint();
+        }
     }
     
     private void updateControllerSetupPanel() {
         controller_panel.removeAll();
         javax.swing.JPanel panel = alica_core.getControllerFactory().getSelectedSetupPanel();
-        controller_panel.add(panel);
-        panel.setBounds(5,5,200,150);
-        panel.revalidate();
-        panel.repaint();
+        if (panel != null) {
+            controller_panel.add(panel);
+            panel.setBounds(5,5,200,150);
+            panel.revalidate();
+            panel.repaint();
+        }
     }
     
     /**

--- a/src/ch/epfl/leb/alica/analyzers/AnalyzerFactory.java
+++ b/src/ch/epfl/leb/alica/analyzers/AnalyzerFactory.java
@@ -20,7 +20,6 @@
 package ch.epfl.leb.alica.analyzers;
 
 import ch.epfl.leb.alica.AbstractFactory;
-import ch.epfl.leb.alica.AlicaLogger;
 import ch.epfl.leb.alica.Analyzer;
 import ch.epfl.leb.alica.analyzers.autolase.AutoLaseSetupPanel;
 import ch.epfl.leb.alica.analyzers.integrator.IntegratorSetupPanel;
@@ -93,7 +92,7 @@ class AnalyzerSetupPanelLoader {
             if (!u.toString().toUpperCase().contains("ALICA_")) {
                 continue;
             } else {
-                AlicaLogger.getInstance().logMessage("Loading ALICA addons from:\n" + u.toString());
+                Logger.getLogger(AnalyzerSetupPanelLoader.class.getName()).log(Level.INFO, "Loading ALICA analyzers from:\n" + u.toString());
             }
             
             // open the jar file

--- a/src/ch/epfl/leb/alica/controllers/ControllerFactory.java
+++ b/src/ch/epfl/leb/alica/controllers/ControllerFactory.java
@@ -20,7 +20,6 @@
 package ch.epfl.leb.alica.controllers;
 
 import ch.epfl.leb.alica.AbstractFactory;
-import ch.epfl.leb.alica.AlicaLogger;
 import ch.epfl.leb.alica.Controller;
 import ch.epfl.leb.alica.controllers.inverter.InverterSetupPanel;
 import ch.epfl.leb.alica.controllers.manual.ManualSetupPanel;
@@ -109,7 +108,7 @@ class ControllerSetupPanelLoader {
             if (!u.toString().toUpperCase().contains("ALICA_")) {
                 continue;
             } else {
-                AlicaLogger.getInstance().logMessage("Loading ALICA addons from:\n" + u.toString());
+                Logger.getLogger(ControllerSetupPanelLoader.class.getName()).log(Level.INFO, "Loading ALICA analyzers from:\n" + u.toString());
             }
             
             // open the jar file


### PR DESCRIPTION
I modified the `build.xml` to create an `ALICA_for_SASS.jar` release. This release only contains the bare classes necessary to use Analyzers and Controllers in SASS, and clocks in at a very slim 71KB. This reduces the final SASS release size to 8MB.

In the future, this release could break if any of the "stock" analyzers or controllers included in this release start making use of an external library that is not available at runtime (i.e. is not included in either MicroManager or FIJI). The JRE would go looking for a class that is not present, because it was stripped during creation of `ALICA_for_SASS.jar`. `ALICA_dev.jar` is guaranteed to have all necessary classes included. However, currently no external libraries are being used so this is a nice way how to reduce file size.